### PR TITLE
eliminate weirdness when hitting Reset Board button multiple times

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -42,13 +42,16 @@ function resetBoard(){
     fen = getNewFen();
     board.position(fen);
 }
+
+var clearBoardTimeout;
 function resetClick(){
+    clearTimeout(clearBoardTimeout);
     preview = true;
     var fen = board.fen()
     console.log(fen);
     resetBoard();
     var delay = 1000*document.getElementById("timeDelay").value
-    setTimeout(clearBoard, delay);
+    clearBoardTimeout = setTimeout(clearBoard, delay);
 }
 function submitBoard(){
     if(!preview){


### PR DESCRIPTION
resolves #1 

@capalmer1013 i saw your comment about using a lock, which would also work as an alternative approach but i decided to instead fix it by cancelling the timer for clearing the board, if the timer happens to already be set, every time we click the Reset Board button. i had to make the change in my own fork because you [haven't invited me as a contributor yet](https://github.com/capalmer1013/chess_memory/issues/1#issuecomment-778568462). once you do, i can just delete the fork once this PR is merged and then work directly off of your original git repo.